### PR TITLE
parseIntで10進数に変換するように明示的に指定した

### DIFF
--- a/main.gs
+++ b/main.gs
@@ -29,8 +29,8 @@ loadDateUtils = function () {
 
       // 1時20, 2:30, 3:00pm
       if(matches[2] != null) {
-        hour = parseInt(matches[2]);
-        min = parseInt(matches[3] ? matches[3] : '0');
+        hour = parseInt(matches[2], 10);
+        min = parseInt((matches[3] ? matches[3] : '0'), 10);
         if(_.contains(['pm'], matches[4])) {
           hour += 12;
         }
@@ -38,8 +38,8 @@ loadDateUtils = function () {
 
       // 午後1 午後2時30 pm3
       if(matches[5] != null) {
-        hour = parseInt(matches[6]);
-        min = parseInt(matches[8] ? matches[8] : '0');
+        hour = parseInt(matches[6], 10);
+        min = parseInt((matches[8] ? matches[8] : '0'), 10);
         if(_.contains(['pm', '午後'], matches[5])) {
           hour += 12;
         }
@@ -47,8 +47,8 @@ loadDateUtils = function () {
 
       // 1am 2:30pm
       if(matches[9] != null) {
-        hour = parseInt(matches[9]);
-        min = parseInt(matches[11] ? matches[11] : '0');
+        hour = parseInt(matches[9], 10);
+        min = parseInt((matches[11] ? matches[11] : '0'), 10);
         if(_.contains(['pm'], matches[12])) {
           hour += 12;
         }
@@ -56,7 +56,7 @@ loadDateUtils = function () {
 
       // 14時
       if(matches[13] != null) {
-        hour = parseInt(matches[13]);
+        hour = parseInt(matches[13], 10);
         min = 0;
       }
 
@@ -88,9 +88,9 @@ loadDateUtils = function () {
     var reg = /((\d{4})[-\/年]{1}|)(\d{1,2})[-\/月]{1}(\d{1,2})/;
     var matches = str.match(reg);
     if(matches) {
-      var year = parseInt(matches[2]);
-      var month = parseInt(matches[3]);
-      var day = parseInt(matches[4]);
+      var year = parseInt(matches[2], 10);
+      var month = parseInt(matches[3], 10);
+      var day = parseInt(matches[4], 10);
       if(_.isNaN(year) || year < 1970) {
         //
         if((now().getMonth() + 1) >= 11 && month <= 2) {
@@ -476,7 +476,7 @@ loadGSTimesheets = function () {
     var rowNo = this.scheme.properties.length + 4;
     var startAt = DateUtils.parseDate(this.settings.get("開始日"));
     var s = new Date(startAt[0], startAt[1]-1, startAt[2], 0, 0, 0);
-    rowNo += parseInt((date.getTime()-date.getTimezoneOffset()*60*1000)/(1000*24*60*60)) - parseInt((s.getTime()-s.getTimezoneOffset()*60*1000)/(1000*24*60*60));
+    rowNo += parseInt((date.getTime()-date.getTimezoneOffset()*60*1000)/(1000*24*60*60), 10) - parseInt((s.getTime()-s.getTimezoneOffset()*60*1000)/(1000*24*60*60), 10);
     return rowNo;
   };
 

--- a/scripts/date_utils.js
+++ b/scripts/date_utils.js
@@ -26,8 +26,8 @@ loadDateUtils = function () {
 
       // 1時20, 2:30, 3:00pm
       if(matches[2] != null) {
-        hour = parseInt(matches[2]);
-        min = parseInt(matches[3] ? matches[3] : '0');
+        hour = parseInt(matches[2], 10);
+        min = parseInt((matches[3] ? matches[3] : '0'), 10);
         if(_.contains(['pm'], matches[4])) {
           hour += 12;
         }
@@ -35,8 +35,8 @@ loadDateUtils = function () {
 
       // 午後1 午後2時30 pm3
       if(matches[5] != null) {
-        hour = parseInt(matches[6]);
-        min = parseInt(matches[8] ? matches[8] : '0');
+        hour = parseInt(matches[6], 10);
+        min = parseInt((matches[8] ? matches[8] : '0'), 10);
         if(_.contains(['pm', '午後'], matches[5])) {
           hour += 12;
         }
@@ -44,8 +44,8 @@ loadDateUtils = function () {
 
       // 1am 2:30pm
       if(matches[9] != null) {
-        hour = parseInt(matches[9]);
-        min = parseInt(matches[11] ? matches[11] : '0');
+        hour = parseInt(matches[9], 10);
+        min = parseInt((matches[11] ? matches[11] : '0'), 10);
         if(_.contains(['pm'], matches[12])) {
           hour += 12;
         }
@@ -53,7 +53,7 @@ loadDateUtils = function () {
 
       // 14時
       if(matches[13] != null) {
-        hour = parseInt(matches[13]);
+        hour = parseInt(matches[13], 10);
         min = 0;
       }
 
@@ -85,9 +85,9 @@ loadDateUtils = function () {
     var reg = /((\d{4})[-\/年]{1}|)(\d{1,2})[-\/月]{1}(\d{1,2})/;
     var matches = str.match(reg);
     if(matches) {
-      var year = parseInt(matches[2]);
-      var month = parseInt(matches[3]);
-      var day = parseInt(matches[4]);
+      var year = parseInt(matches[2], 10);
+      var month = parseInt(matches[3], 10);
+      var day = parseInt(matches[4], 10);
       if(_.isNaN(year) || year < 1970) {
         //
         if((now().getMonth() + 1) >= 11 && month <= 2) {

--- a/scripts/gs_timesheets.js
+++ b/scripts/gs_timesheets.js
@@ -58,7 +58,7 @@ loadGSTimesheets = function () {
     var rowNo = this.scheme.properties.length + 4;
     var startAt = DateUtils.parseDate(this.settings.get("開始日"));
     var s = new Date(startAt[0], startAt[1]-1, startAt[2], 0, 0, 0);
-    rowNo += parseInt((date.getTime()-date.getTimezoneOffset()*60*1000)/(1000*24*60*60)) - parseInt((s.getTime()-s.getTimezoneOffset()*60*1000)/(1000*24*60*60));
+    rowNo += parseInt((date.getTime()-date.getTimezoneOffset()*60*1000)/(1000*24*60*60), 10) - parseInt((s.getTime()-s.getTimezoneOffset()*60*1000)/(1000*24*60*60), 10);
     return rowNo;
   };
 


### PR DESCRIPTION
Google App Scriptの挙動変更のせいか、出勤退勤などができなくなったので修正をかけました。
8や9といった数字でNaNを返してしまい、該当する日付のレコードを検索する箇所でエラーを吐いていたようです。